### PR TITLE
feat: inject mediaType to image manifest

### DIFF
--- a/source-container-build/0001-Set-mediaType-on-image-manifest.patch
+++ b/source-container-build/0001-Set-mediaType-on-image-manifest.patch
@@ -1,0 +1,24 @@
+From 9962ccf0dc464bcc3da5ee36c199c0dfff098055 Mon Sep 17 00:00:00 2001
+From: Chenxiong Qi <cqi@redhat.com>
+Date: Tue, 18 Jun 2024 22:48:25 +0800
+Subject: [PATCH] Set mediaType on image manifest
+
+---
+ BuildSourceImage.sh | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/BuildSourceImage.sh b/BuildSourceImage.sh
+index ace5232..c1a8bf1 100755
+--- a/BuildSourceImage.sh
++++ b/BuildSourceImage.sh
+@@ -544,6 +544,7 @@ layout_new_bash() {
+     mnfst='
+ {
+   "schemaVersion": 2,
++  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+   "config": {
+     "mediaType": "application/vnd.oci.image.config.v1+json",
+     "digest": "sha256:'"${config_sum}"'",
+-- 
+2.45.1
+

--- a/source-container-build/Dockerfile
+++ b/source-container-build/Dockerfile
@@ -5,16 +5,17 @@ ARG bsi_source=https://github.com/containers/BuildSourceImage/archive/refs/tags/
 ARG patch0=0001-cleanup-directory-with-all-rpms-which-isn-t-used-any.patch
 ARG patch1=0001-Increase-counter-as-numeric-rather-than-string.patch
 ARG patch2=0001-Use-extra-src-archive-checksum-in-filename.patch
+ARG patch3=0001-Set-mediaType-on-image-manifest.patch
 
 # hadolint ignore=DL3041
 RUN dnf update -y && dnf install -y python3.11 git jq skopeo file tar && dnf clean all
 
 WORKDIR /opt/BuildSourceImage
-COPY $patch0 $patch1 $patch2 ./
+COPY $patch0 $patch1 $patch2 $patch3 ./
 RUN curl -s -O -L $bsi_source && \
     tar --extract -f v${BSI_VERSION}.tar.gz -z --strip-components=1 BuildSourceImage-${BSI_VERSION}/BuildSourceImage.sh && \
-    git apply --allow-empty BuildSourceImage.sh $patch0 $patch1 $patch2 && \
-    rm -r $patch0 $patch1 $patch2 && \
+    git apply --allow-empty BuildSourceImage.sh $patch0 $patch1 $patch2 $patch3 && \
+    rm -r $patch0 $patch1 $patch2 $patch3 && \
     mv BuildSourceImage.sh bsi
 
 WORKDIR /opt/source_build/


### PR DESCRIPTION
STONEBLD-2508

BuildSourceImage.sh is patched by injecting mediaType into the image manifest explicitly.