### PR TITLE
Change e2e image to konflux workloads

### DIFF
--- a/integration-tests/tasks/e2e-test.yaml
+++ b/integration-tests/tasks/e2e-test.yaml
@@ -18,7 +18,7 @@ spec:
       type: string
   steps:
     - name: e2e-test
-      image: quay.io/konflux-ci/e2e-tests:4dfb77a4e8d3ce8bf5ebc8eeac8cb353874f8625
+      image: quay.io/redhat-user-workloads/rhtap-qe-shared-tenant/konflux-e2e/konflux-e2e-tests:7dab163f24f482021262680e7a602d6af84ca84b
       args: [
         "--ginkgo.label-filter=source-build-e2e",
         "--ginkgo.no-color",


### PR DESCRIPTION
E2e tests repo was onboarded in Konflux and now is using user workloads to save quay images