### PR TITLE
Fix e2e test pipeline

### DIFF
--- a/integration-tests/pipelines/e2e-tests-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-tests-pipeline.yaml
@@ -32,7 +32,7 @@ spec:
               echo "SNAPSHOT: ${SNAPSHOT}"
               export SOURCE_IMAGE=$(jq -r .components[0].containerImage <<< "$SNAPSHOT")
               echo "Built image: ${SOURCE_IMAGE}"
-              
+
               git clone --branch main https://github.com/redhat-appstudio/e2e-tests.git
               cd e2e-tests/
               make setup-source-build | tee cmd_output
@@ -67,9 +67,6 @@ spec:
           - name: pathInRepo
             value: integration-tests/tasks/e2e-test.yaml
       timeout: "2h"
-  
+
   timeouts:
     pipeline: "2h"
-
-
-

--- a/integration-tests/pipelines/e2e-tests-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-tests-pipeline.yaml
@@ -67,6 +67,3 @@ spec:
           - name: pathInRepo
             value: integration-tests/tasks/e2e-test.yaml
       timeout: "2h"
-
-  timeouts:
-    pipeline: "2h"


### PR DESCRIPTION
The spec.timeouts property is causing errors

    Error retrieving pipeline for pipelinerun ...:
    resolver failed to get Pipeline : invalid runtime object:
    strict decoding error: unknown field "spec.timeouts"