### PR TITLE
sbom-utils: tag image with 'latest' as well

### DIFF
--- a/.github/workflows/build-sbom-utility-scripts-image.yml
+++ b/.github/workflows/build-sbom-utility-scripts-image.yml
@@ -54,7 +54,9 @@ jobs:
       uses: redhat-actions/buildah-build@v2
       with:
         image: ${{ env.IMAGE_NAME }}
-        tags: ${{ github.sha }}
+        tags: |
+          ${{ github.sha }}
+          latest
         context: ./sbom-utility-scripts
         containerfiles: |
             ./sbom-utility-scripts/Dockerfile


### PR DESCRIPTION
It would seem that when an image only has git sha tags, Renovate updates don't quite work properly. Add a 'latest' tag.