### PR TITLE
Add rpms signature scan task

### DIFF
--- a/.tekton/source-container-build-pull-request.yaml
+++ b/.tekton/source-container-build-pull-request.yaml
@@ -226,6 +226,23 @@ spec:
         operator: in
         values:
         - "true"
+    - name: rpms-signature-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-container.results.IMAGE_URL)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: rpms-signature-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:0c9667fba291af05997397a32e5e938ccaa46e93a2e14bad228e64a6427c5545
+        - name: kind
+          value: task
+        resolver: bundles
     - name: build-source-image
       params:
       - name: BINARY_IMAGE

--- a/.tekton/source-container-build-push.yaml
+++ b/.tekton/source-container-build-push.yaml
@@ -223,6 +223,23 @@ spec:
         operator: in
         values:
         - "true"
+    - name: rpms-signature-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-container.results.IMAGE_URL)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: rpms-signature-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:0c9667fba291af05997397a32e5e938ccaa46e93a2e14bad228e64a6427c5545
+        - name: kind
+          value: task
+        resolver: bundles
     - name: build-source-image
       params:
       - name: BINARY_IMAGE


### PR DESCRIPTION
Seems like this is now mandatory for releases.
Otherwise the EC checks during release fail with:

Violation] tasks.required_tasks_found
  ImageRef: quay.io/redhat-user-workloads/rhtap-build-tenant/build-tasks-dockerfiles/source-container-build@sha256:17ecaec885882f4e6a12bc599337ca7686d7fe43db3c1ed479c597fc1cc17615
  Reason: Required task "rpms-signature-scan" is missing
  Title: All required tasks were included in the pipeline
  Description: Ensure that the set of required tasks are included in the PipelineRun attestation. To exclude this rule add
  "tasks.required_tasks_found:rpms-signature-scan" to the `exclude` section of the policy configuration.
  Solution: Make sure all required tasks are in the build pipeline. The required task list is contained as
  xref:ec-cli:ROOT:configuration.adoc#_data_sources[data] under the key 'required-tasks'.