### PR TITLE
Add a script for sbom enrichment

### DIFF
--- a/.github/workflows/build-sbom-utility-scripts-image.yml
+++ b/.github/workflows/build-sbom-utility-scripts-image.yml
@@ -7,7 +7,7 @@ on:
     paths:
       - .github/workflows/build-sbom-utility-scripts-image.yml
       - sbom-utility-scripts/**
-    
+
   pull_request:
     branches:
       - main
@@ -19,7 +19,7 @@ on:
 env:
   REGISTRY: quay.io/redhat-appstudio
   IMAGE_NAME: sbom-utility-scripts-image
-  
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -27,7 +27,7 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
-      
+
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
@@ -38,7 +38,7 @@ jobs:
         python3 -m pip install tox
         cd ./sbom-utility-scripts/scripts/base-images-sbom-script/app/
         tox
-     
+
     - name: Run tox checks for merge-cachi2-sboms-script
       run: |
         python3 -m pip install tox
@@ -49,6 +49,12 @@ jobs:
       run: |
         python3 -m pip install tox
         cd ./sbom-utility-scripts/scripts/index-image-sbom-script/
+        tox
+
+    - name: Run tox checks for index-image-sbom-script
+      run: |
+        python3 -m pip install tox
+        cd ./sbom-utility-scripts/scripts/add-image-reference-script/
         tox
 
     - name: Build Image
@@ -72,4 +78,3 @@ jobs:
         registry: ${{ env.REGISTRY }}
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_PASSWORD }}
-

--- a/sbom-utility-scripts/Dockerfile
+++ b/sbom-utility-scripts/Dockerfile
@@ -10,4 +10,10 @@ COPY scripts/base-images-sbom-script/app/requirements.txt /scripts/base-images-s
 COPY scripts/index-image-sbom-script/requirements.txt /scripts/index-image-sbom-script-requirements.txt
 COPY scripts/index-image-sbom-script/index_image_sbom_script.py /scripts
 
-RUN pip3 install -r base-images-sbom-script-requirements.txt -r index-image-sbom-script-requirements.txt
+COPY scripts/add-image-reference-script/add_image_reference.py /scripts
+COPY scripts/add-image-reference-script/requirements.txt /scripts/add-image-reference-requirements.txt
+
+RUN pip3 install --no-cache-dir \
+    -r base-images-sbom-script-requirements.txt \
+    -r index-image-sbom-script-requirements.txt \
+    -r add-image-reference-requirements.txt

--- a/sbom-utility-scripts/scripts/add-image-reference-script/README.md
+++ b/sbom-utility-scripts/scripts/add-image-reference-script/README.md
@@ -1,0 +1,144 @@
+# Add image reference script
+
+The script aims to enrich the SBOM file with additional information about the output image used in the build process.
+Based on a input SBOM type, the script updates certain fields with the image reference information. This is needed
+to provide a complete SBOM file that can be used for further analysis.
+
+## Usage
+
+```bash
+python add_image_reference.py \
+    --input-file ./input-sbom.json \
+    --output-file ./updated-sbom.json \
+    --image-url quay.io/foo/bar/ubi8:1.1 \
+    --image-digest sha256:011ff0cd8f34588d3eca86da97619f7baf99c8cc12e24cc3a7f337873c8d36cc
+```
+The script stores the updated SBOM in the output path provided.
+
+## List of updates
+### SPDX
+The script updates the following fields in the SPDX SBOM:SHA256
+- `packages` - the script adds a new package with the image reference information
+- `relationships` - the script adds a new relationship between the package and the image reference
+- `name` - the script adds the image reference as a name
+
+The logic of adding new packages and updating replationships is visualized in the following diagram:
+```
+example SPDX SBOM:
+
+                ROOT
+             /        \
+            /          \
+        DESCRIBES   DESCRIBES
+          /              \
+         /                \
+<pip main package>  <npm main package>
+        |                  |
+        |                  |
+     CONTAINS           CONTAINS
+        |                  |
+        |                  |
+    <pip deps>         <npm deps>
+
+
+SBOM after enrichment:
+
+                ROOT
+                 |
+                 |
+              DESCRIBES
+                 |
+                 |
+             <container>
+             /        \
+            /          \
+        CONTAINS    CONTAINS
+          /              \
+         /                \
+<pip main package>  <npm main package>
+        |                  |
+        |                  |
+     CONTAINS           CONTAINS
+        |                  |
+        |                  |
+    <pip deps>         <npm deps>
+
+```
+
+#### Example
+```json
+{
+  "name": "quay.io/foo/bar/ubi8@sha256:011ff0cd8f34588d3eca86da97619f7baf99c8cc12e24cc3a7f337873c8d36cc",
+  "packages": [
+    {
+      "SPDXID": "SPDXRef-image",
+      "name": "ubi8",
+      "versionInfo": "1.1",
+      "downloadLocation": "NOASSERTION",
+      "licenseConcluded": "NOASSERTION",
+      "supplier": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceLocator": "pkg:oci/ubi8@sha256:011ff0cd8f34588d3eca86da97619f7baf99c8cc12e24cc3a7f337873c8d36cc?repository_url=quay.io/foo/bar/ubi8",
+          "referenceType": "purl",
+          "referenceCategory": "PACKAGE-MANAGER"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "011ff0cd8f34588d3eca86da97619f7baf99c8cc12e24cc3a7f337873c8d36cc"
+        }
+      ]
+    },
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-image"
+    },
+  ]
+}
+
+```
+
+### CycloneDX
+- `components` - the script adds a new component with the image reference information
+- `metadata.component` - the script adds the image reference as a metadata.component
+
+#### Example
+```json
+{
+  "metadata": {
+    "component": {
+      "type": "container",
+      "name": "ubi8",
+      "purl": "pkg:oci/ubi8@sha256:011ff0cd8f34588d3eca86da97619f7baf99c8cc12e24cc3a7f337873c8d36cc?repository_url=quay.io/foo/bar/ubi8",
+      "version": "1.1",
+      "publisher": "Red Hat, Inc.",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "011ff0cd8f34588d3eca86da97619f7baf99c8cc12e24cc3a7f337873c8d36cc"
+        }
+      ]
+    },
+  },
+  "components": [
+    {
+      "type": "container",
+      "name": "ubi8",
+      "purl": "pkg:oci/ubi8@sha256:011ff0cd8f34588d3eca86da97619f7baf99c8cc12e24cc3a7f337873c8d36cc?repository_url=quay.io/foo/bar/ubi8",
+      "version": "1.1",
+      "publisher": "Red Hat, Inc.",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "011ff0cd8f34588d3eca86da97619f7baf99c8cc12e24cc3a7f337873c8d36cc"
+        }
+      ]
+    },
+  ]
+}
+```

--- a/sbom-utility-scripts/scripts/add-image-reference-script/add_image_reference.py
+++ b/sbom-utility-scripts/scripts/add-image-reference-script/add_image_reference.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from packageurl import PackageURL
+
+
+@dataclass
+class Image:
+    repository: str
+    name: str
+    digest: str
+    tag: str
+
+    @staticmethod
+    def from_image_index_url_and_digest(
+        image_url_and_tag: str,
+        image_digest: str,
+    ) -> "Image":
+        """
+        Create an instance of the Image class from the image URL and digest.
+
+        Args:
+            image_url_and_tag (str): Image URL in the format 'registry.com/repository/image:tag'.
+            image_digest (str): Manifest digest of the image. (sha256:digest)
+
+        Returns:
+            Image: An instance of the Image class representing the image.
+        """
+        repository, tag = image_url_and_tag.rsplit(":", 1)
+        _, name = repository.rsplit("/", 1)
+        return Image(
+            repository=repository,
+            name=name,
+            digest=image_digest,
+            tag=tag,
+        )
+
+    @property
+    def digest_algo_cyclonedx(self) -> str:
+        """
+        Get the digest algorithm used for the image in cyclonedx format.
+        The output is in uppercase.
+
+        Returns:
+            str: Algorithm used for the digest.
+        """
+        algo, _ = self.digest.split(":")
+        mapping = {"sha256": "SHA-256", "sha512": "SHA-512"}
+        return mapping.get(algo, algo.upper())
+
+    @property
+    def digest_algo_spdx(self) -> str:
+        """
+        Get the digest algorithm used for the image in SPDX format.
+
+        Returns:
+            str: Algorithm used for the digest in SPDX format.
+        """
+        algo, _ = self.digest.split(":")
+        return algo.upper()
+
+    @property
+    def digest_hex_val(self) -> str:
+        """
+        Get the digest value of the image in hexadecimal format.
+
+        Returns:
+            str: Digest value in hexadecimal format.
+        """
+        _, val = self.digest.split(":")
+        return val
+
+    def purl(self) -> str:
+        """
+        Get the Package URL (PURL) for the image.
+
+        Returns:
+            str: A string representing the PURL for the image.
+        """
+        return PackageURL(
+            type="oci",
+            name=self.name,
+            version=self.digest,
+            qualifiers={"repository_url": self.repository},
+        ).to_string()
+
+
+def setup_arg_parser() -> argparse.ArgumentParser:
+    """
+    Setup the argument parser for the script.
+
+    Returns:
+        argparse.ArgumentParser: Argument parser for the script.
+    """
+    parser = argparse.ArgumentParser(description="Add image reference to image SBOM.")
+    parser.add_argument(
+        "--image-url",
+        type=str,
+        help="Image URL in the format 'registry.com/repository/image:tag'.",
+        required=True,
+    )
+    parser.add_argument(
+        "--image-digest",
+        type=str,
+        help="Image manifest digest in a form sha256:xxxx.",
+        required=True,
+    )
+    parser.add_argument(
+        "--input-file",
+        "-i",
+        type=Path,
+        help="SBOM file in JSON format.",
+        required=True,
+    )
+    parser.add_argument(
+        "--output-file",
+        "-o",
+        type=str,
+        help="Path to save the output SBOM in JSON format.",
+    )
+    return parser
+
+
+def update_component_in_cyclonedx_sbom(sbom: dict, image: Image) -> dict:
+    """
+    Update the CycloneDX SBOM with the image reference.
+
+    The reference to the image is added to the SBOM in the form of a component and
+    purl is added to the metadata.
+
+    Args:
+        sbom (dict): SBOM in JSON format.
+        image (Image): An instance of the Image class that represents the image.
+
+    Returns:
+        dict: Updated SBOM with the image reference added.
+    """
+    # Add the image component to the components list
+    image_component = {
+        "type": "container",
+        "name": image.name,
+        "purl": image.purl(),
+        "version": image.tag,
+        "hashes": [{"alg": image.digest_algo_cyclonedx, "content": image.digest_hex_val}],
+    }
+    sbom["components"].insert(0, image_component)
+    sbom["metadata"]["component"] = image_component
+    return sbom
+
+
+def find_package_by_spdx_id(sbom: dict, spdx_id: str) -> Optional[dict]:
+    """
+    Find the package in the SBOM by SPDX ID.
+
+    Args:
+        sbom (dict): SBOM in JSON format.
+        spdx_id (str): SPDX ID of the package to find.
+
+    Returns:
+        dict: The package with the given SPDX ID.
+    """
+    for package in sbom["packages"]:
+        if package["SPDXID"] == spdx_id:
+            return package
+    return None
+
+
+def delete_package_by_spdx_id(sbom: dict, spdx_id: str) -> dict:
+    """
+    Delete the package in the SBOM by SPDX ID.
+
+    Args:
+        sbom (dict): SBOM in JSON format.
+        spdx_id (str): SPDX ID of the package to delete.
+
+    Returns:
+        dict: Updated SBOM with the package deleted.
+    """
+    for package in sbom["packages"]:
+        if package["SPDXID"] == spdx_id:
+            sbom["packages"].remove(package)
+            break
+    return sbom
+
+
+def redirect_virtual_root_to_new_root(sbom: dict, virtual_root: str, new_root: str) -> dict:
+    """
+    Redirect the relationship describing the document to a new root node.
+
+    Args:
+        sbom (dict): SBOM in JSON format.
+        virtual_root (str): A virtual root node identifier that needs to be replaced.
+        new_root (str): A new root node identifier that will replace the virtual root node.
+
+    Returns:
+        dict: Updated SBOM with the virtual root node replaced.
+    """
+    for relationship in sbom["relationships"]:
+        if relationship["spdxElementId"] == virtual_root:
+            relationship["spdxElementId"] = new_root
+
+        if relationship["relatedSpdxElement"] == virtual_root:
+            relationship["relatedSpdxElement"] = new_root
+
+
+def delete_relationship_by_related_spdx_id(sbom: dict, spdx_id: str) -> dict:
+    """
+    Delete the relationship in the SBOM by SPDX ID.
+
+    Args:
+        sbom (dict): SBOM in JSON format.
+        spdx_id (str): SPDX ID of the relationship to delete.
+
+    Returns:
+        dict: Updated SBOM with the relationship deleted.
+    """
+    for relationship in sbom["relationships"]:
+        if relationship["relatedSpdxElement"] == spdx_id:
+            sbom["relationships"].remove(relationship)
+            break
+    return sbom
+
+
+def describes_the_document(relationship_element: dict, doc_spdx_id: str) -> bool:
+    """
+    Check if the relationship describes the document.
+
+    Args:
+        relationship_element (dict): A relationship element from the SBOM that needs to be checked.
+        doc_spdx_id (str): A SPDX ID of the document.
+
+    Returns:
+        bool: A boolean indicating if the relationship describes the document.
+    """
+    return (
+        relationship_element["spdxElementId"] == doc_spdx_id and relationship_element["relationshipType"] == "DESCRIBES"
+    )
+
+
+def is_virtual_root(package: dict) -> bool:
+    """
+    Check if the package is a virtual - usually a package with empty values.
+
+    Args:
+        package (dict): A package element from the SBOM.
+
+    Returns:
+        bool: A boolean indicating if the package is a virtual root.
+    """
+    return not package.get("name")
+
+
+def redirect_current_roots_to_new_root(sbom: dict, new_root: str) -> dict:
+    """
+    Redirect all the current root nodes to a new root node.
+
+    Args:
+        sbom (dict): SBOM in JSON format.
+        new_root (str): New root node identifier.
+
+    Returns:
+        dict: Updated SBOM with the new root node identifier.
+    """
+    for relationship in sbom["relationships"]:
+        if not describes_the_document(relationship, sbom["SPDXID"]):
+            continue
+
+        current_root = find_package_by_spdx_id(sbom, relationship["relatedSpdxElement"])
+
+        if is_virtual_root(current_root):
+            # In case the document is described by the virtual root node let's remove it and replace it with
+            # the new root node
+
+            # Remove the virtual root node from the packages list
+            delete_package_by_spdx_id(sbom, relationship["relatedSpdxElement"])
+
+            # Remove the relationship between the document and the virtual root node
+            delete_relationship_by_related_spdx_id(sbom, relationship["relatedSpdxElement"])
+
+            # Redirect a existing relationship to the new root node
+            redirect_virtual_root_to_new_root(sbom, relationship["relatedSpdxElement"], new_root)
+        else:
+            # Make an edge between the new root node and the current root node
+            relationship["spdxElementId"] = new_root
+            relationship["relationshipType"] = "CONTAINS"
+    return sbom
+
+
+def update_package_in_spdx_sbom(sbom: dict, image: Image) -> dict:
+    """
+    Update the SPDX SBOM with the image reference.
+
+    The reference to the image is added to the SBOM in the form of a package and
+    appropriate relationships are added to the SBOM.
+
+    Args:
+        sbom (dict): SBOM in JSON format.
+        image (Image): An instance of the Image class that represents the image.
+
+    Returns:
+        dict: Updated SBOM with the image reference added.
+    """
+    # Add the image package to the packages list
+    package = {
+        "SPDXID": "SPDXRef-image",
+        "name": image.name,
+        "versionInfo": image.tag,
+        "downloadLocation": "NOASSERTION",
+        "licenseConcluded": "NOASSERTION",
+        "supplier": "NOASSERTION",
+        "externalRefs": [
+            {
+                "referenceLocator": image.purl(),
+                "referenceType": "purl",
+                "referenceCategory": "PACKAGE-MANAGER",
+            }
+        ],
+        "checksums": [{"algorithm": image.digest_algo_spdx, "checksumValue": image.digest_hex_val}],
+    }
+    sbom["packages"].insert(0, package)
+
+    # Check existing relationships and redirect the current roots to the new root
+    redirect_current_roots_to_new_root(sbom, package["SPDXID"])
+
+    # Add the relationship between the image and the package
+    sbom["relationships"].insert(
+        0,
+        {
+            "spdxElementId": sbom["SPDXID"],
+            "relationshipType": "DESCRIBES",
+            "relatedSpdxElement": package["SPDXID"],
+        },
+    )
+    return sbom
+
+
+def extend_sbom_with_image_reference(sbom: dict, image: Image) -> dict:
+    """
+    Extend the SBOM with the image reference.
+    Based on the SBOM format, the image reference is added to the SBOM in
+    a different way.
+
+    Args:
+        sbom (dict): SBOM in JSON format.
+        image (Image): An instance of the Image class that represents the image.
+
+    Returns:
+        dict: Updated SBOM with the image reference added.
+    """
+    if sbom.get("bomFormat") == "CycloneDX":
+        update_component_in_cyclonedx_sbom(sbom, image)
+    elif "spdxVersion" in sbom:
+        update_package_in_spdx_sbom(sbom, image)
+
+    return sbom
+
+
+def update_name(sbom: dict, image: Image) -> dict:
+    """
+    Update the SBOM name with the image reference in the format 'repository@digest'.
+
+    Args:
+        sbom (dict): SBOM in JSON format.
+        image (Image): An instance of the Image class that represents the image.
+
+    Returns:
+        dict: Updated SBOM with the name field updated.
+    """
+    if "spdxVersion" in sbom:
+        sbom["name"] = f"{image.repository}@{image.digest}"
+    return sbom
+
+
+def main():
+    """
+    Main function to add image reference to SBOM.
+    """
+    arg_parser = setup_arg_parser()
+    args = arg_parser.parse_args()
+
+    with open(args.input_file, "r") as inp_file:
+        sbom = json.load(inp_file)
+
+    image = Image.from_image_index_url_and_digest(
+        args.image_url,
+        args.image_digest,
+    )
+
+    # Update the input SBOM with the image reference and name attributes
+    sbom = extend_sbom_with_image_reference(sbom, image)
+    sbom = update_name(sbom, image)
+
+    # Save the updated SBOM to the output file
+    if args.output_file:
+        with open(args.output_file, "w") as out_file:
+            json.dump(sbom, out_file)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/sbom-utility-scripts/scripts/add-image-reference-script/requirements-test.txt
+++ b/sbom-utility-scripts/scripts/add-image-reference-script/requirements-test.txt
@@ -1,0 +1,5 @@
+black==24.10.0
+flake8==7.1.1
+pytest-mock==3.14.0
+pytest==8.3.3
+pytest-cov==6.0.0

--- a/sbom-utility-scripts/scripts/add-image-reference-script/requirements.txt
+++ b/sbom-utility-scripts/scripts/add-image-reference-script/requirements.txt
@@ -1,0 +1,1 @@
+packageurl-python==0.15.0

--- a/sbom-utility-scripts/scripts/add-image-reference-script/test_add_image_reference.py
+++ b/sbom-utility-scripts/scripts/add-image-reference-script/test_add_image_reference.py
@@ -1,0 +1,272 @@
+from unittest.mock import MagicMock, patch
+
+import add_image_reference
+
+
+def test_setup_arg_parser() -> None:
+    parser = add_image_reference.setup_arg_parser()
+    assert parser.description == "Add image reference to image SBOM."
+    assert parser._option_string_actions["--image-url"].required
+    assert parser._option_string_actions["--image-digest"].required
+
+
+def test_Image() -> None:
+    image = add_image_reference.Image.from_image_index_url_and_digest(
+        "quay.io/namespace/repository/image:tag", "sha256:digest"
+    )
+
+    assert image.repository == "quay.io/namespace/repository/image"
+    assert image.name == "image"
+    assert image.digest == "sha256:digest"
+    assert image.tag == "tag"
+
+    assert image.digest_algo_cyclonedx == "SHA-256"
+    assert image.digest_algo_spdx == "SHA256"
+    assert image.digest_hex_val == "digest"
+
+    assert image.purl() == ("pkg:oci/image@sha256:digest?repository_url=quay.io/namespace/repository/image")
+
+
+def test_update_component_in_cyclonedx_sbom() -> None:
+    sbom = {"bomFormat": "CycloneDX", "metadata": {"component": {}}, "components": [{}]}
+    image = add_image_reference.Image.from_image_index_url_and_digest(
+        "quay.io/namespace/repository/image:tag",
+        "sha256:digest",
+    )
+
+    result = add_image_reference.update_component_in_cyclonedx_sbom(sbom=sbom, image=image)
+
+    assert (
+        result["metadata"]["component"]["purl"]
+        == "pkg:oci/image@sha256:digest?repository_url=quay.io/namespace/repository/image"
+    )
+    assert len(result["components"]) == 2
+    assert result["components"][0] == {
+        "type": "container",
+        "name": image.name,
+        "purl": image.purl(),
+        "version": image.tag,
+        "hashes": [{"alg": image.digest_algo_cyclonedx, "content": image.digest_hex_val}],
+    }
+    assert result["metadata"]["component"] == result["components"][0]
+
+
+def test_find_package_by_spdx_id() -> None:
+    sbom = {"packages": [{"SPDXID": "foo"}, {"SPDXID": "bar"}]}
+    assert add_image_reference.find_package_by_spdx_id(sbom, "foo") == {"SPDXID": "foo"}
+    assert add_image_reference.find_package_by_spdx_id(sbom, "baz") is None
+
+
+def test_delete_package_by_spdx_id() -> None:
+    sbom = {"packages": [{"SPDXID": "foo"}, {"SPDXID": "bar"}]}
+    add_image_reference.delete_package_by_spdx_id(sbom, "foo")
+    assert sbom["packages"] == [{"SPDXID": "bar"}]
+
+
+def test_redirect_virtual_root_to_new_root() -> None:
+    sbom = {
+        "relationships": [
+            {"spdxElementId": "foo", "relationshipType": "DESCRIBES", "relatedSpdxElement": "bar"},
+            {"spdxElementId": "bar", "relationshipType": "DESCRIBES", "relatedSpdxElement": "baz"},
+            {"spdxElementId": "baz", "relationshipType": "DESCRIBES", "relatedSpdxElement": "qux"},
+        ]
+    }
+    add_image_reference.redirect_virtual_root_to_new_root(sbom, "bar", "qux")
+
+    assert sbom["relationships"] == [
+        {"spdxElementId": "foo", "relationshipType": "DESCRIBES", "relatedSpdxElement": "qux"},
+        {"spdxElementId": "qux", "relationshipType": "DESCRIBES", "relatedSpdxElement": "baz"},
+        {"spdxElementId": "baz", "relationshipType": "DESCRIBES", "relatedSpdxElement": "qux"},
+    ]
+
+
+def test_delete_relationship_by_related_spdx_id() -> None:
+    sbom = {
+        "relationships": [
+            {"spdxElementId": "foo", "relationshipType": "DESCRIBES", "relatedSpdxElement": "bar"},
+            {"spdxElementId": "bar", "relationshipType": "DESCRIBES", "relatedSpdxElement": "baz"},
+            {"spdxElementId": "baz", "relationshipType": "DESCRIBES", "relatedSpdxElement": "qux"},
+        ]
+    }
+    add_image_reference.delete_relationship_by_related_spdx_id(sbom, "baz")
+
+    assert sbom["relationships"] == [
+        {"spdxElementId": "foo", "relationshipType": "DESCRIBES", "relatedSpdxElement": "bar"},
+        {"spdxElementId": "baz", "relationshipType": "DESCRIBES", "relatedSpdxElement": "qux"},
+    ]
+
+
+def test_describes_the_document() -> None:
+    relationship = {
+        "spdxElementId": "SPDXRef-DOCUMENT",
+        "relationshipType": "DESCRIBES",
+        "relatedSpdxElement": "SPDXRef-image",
+    }
+
+    assert add_image_reference.describes_the_document(relationship, "SPDXRef-DOCUMENT") is True
+
+    relationship["spdxElementId"] = "foo"
+
+    assert add_image_reference.describes_the_document(relationship, "SPDXRef-DOCUMENT") is False
+
+
+def test_is_virtual_root() -> None:
+    package = {"SPDXID": "foo", "name": ""}
+
+    assert add_image_reference.is_virtual_root(package) is True
+
+    package["name"] = "bar"
+
+    assert add_image_reference.is_virtual_root(package) is False
+
+
+def test_redirect_current_roots_to_new_root() -> None:
+    # Replacing a virtual root with a new root
+    sbom = {
+        "packages": [
+            {"SPDXID": "virtual", "name": ""},
+            {"SPDXID": "bar", "name": "bar"},
+            {"SPDXID": "baz", "name": "baz"},
+        ],
+        "relationships": [
+            {"spdxElementId": "foo", "relationshipType": "DESCRIBES", "relatedSpdxElement": "virtual"},
+            {"spdxElementId": "virtual", "relationshipType": "CONTAINS", "relatedSpdxElement": "baz"},
+        ],
+        "SPDXID": "foo",
+    }
+    result = add_image_reference.redirect_current_roots_to_new_root(sbom, "bar")
+
+    assert result == {
+        "packages": [
+            {"SPDXID": "bar", "name": "bar"},
+            {"SPDXID": "baz", "name": "baz"},
+        ],
+        "relationships": [
+            {"spdxElementId": "bar", "relationshipType": "CONTAINS", "relatedSpdxElement": "baz"},
+        ],
+        "SPDXID": "foo",
+    }
+
+    # Replacing a root with a new root and redirecting the old root to the new root
+    sbom = {
+        "packages": [
+            {"SPDXID": "npm", "name": "npm"},
+            {"SPDXID": "bar", "name": "bar"},
+            {"SPDXID": "baz", "name": "baz"},
+        ],
+        "relationships": [
+            {"spdxElementId": "foo", "relationshipType": "DESCRIBES", "relatedSpdxElement": "npm"},
+            {"spdxElementId": "npm", "relationshipType": "CONTAINS", "relatedSpdxElement": "baz"},
+        ],
+        "SPDXID": "foo",
+    }
+    result = add_image_reference.redirect_current_roots_to_new_root(sbom, "bar")
+
+    assert result == {
+        "packages": [
+            {"SPDXID": "npm", "name": "npm"},
+            {"SPDXID": "bar", "name": "bar"},
+            {"SPDXID": "baz", "name": "baz"},
+        ],
+        "relationships": [
+            {"spdxElementId": "bar", "relationshipType": "CONTAINS", "relatedSpdxElement": "npm"},
+            {"spdxElementId": "npm", "relationshipType": "CONTAINS", "relatedSpdxElement": "baz"},
+        ],
+        "SPDXID": "foo",
+    }
+
+
+@patch("add_image_reference.redirect_current_roots_to_new_root")
+def test_update_package_in_spdx_sbom(mock_root_redicret: MagicMock) -> None:
+    sbom = {"spdxVersion": "1.1.1", "SPDXID": "foo", "packages": [{}], "relationships": []}
+    image = add_image_reference.Image.from_image_index_url_and_digest(
+        "quay.io/namespace/repository/image:tag",
+        "sha256:digest",
+    )
+
+    result = add_image_reference.update_package_in_spdx_sbom(sbom=sbom, image=image)
+
+    assert len(result["packages"]) == 2
+    assert result["packages"][0] == {
+        "SPDXID": "SPDXRef-image",
+        "name": image.name,
+        "versionInfo": image.tag,
+        "downloadLocation": "NOASSERTION",
+        "licenseConcluded": "NOASSERTION",
+        "supplier": "NOASSERTION",
+        "externalRefs": [
+            {
+                "referenceLocator": image.purl(),
+                "referenceType": "purl",
+                "referenceCategory": "PACKAGE-MANAGER",
+            }
+        ],
+        "checksums": [{"algorithm": image.digest_algo_spdx, "checksumValue": image.digest_hex_val}],
+    }
+
+    assert len(result["relationships"]) == 1
+    assert result["relationships"][0] == {
+        "spdxElementId": sbom["SPDXID"],
+        "relationshipType": "DESCRIBES",
+        "relatedSpdxElement": "SPDXRef-image",
+    }
+
+    mock_root_redicret.assert_called_once_with(sbom, "SPDXRef-image")
+
+
+@patch("add_image_reference.update_package_in_spdx_sbom")
+@patch("add_image_reference.update_component_in_cyclonedx_sbom")
+def test_extend_sbom_with_image_reference(cyclonedx_update: MagicMock, spdx_update: MagicMock) -> None:
+    sbom = {"bomFormat": "CycloneDX"}
+    image = MagicMock()
+    add_image_reference.extend_sbom_with_image_reference(sbom, image)
+
+    cyclonedx_update.assert_called_once_with(sbom, image)
+    spdx_update.assert_not_called()
+
+    cyclonedx_update.reset_mock()
+    spdx_update.reset_mock()
+
+    sbom = {"spdxVersion": "1.1.1"}
+    add_image_reference.extend_sbom_with_image_reference(sbom, image)
+
+    cyclonedx_update.assert_not_called()
+    spdx_update.assert_called_once_with(sbom, image)
+
+
+def test_update_name() -> None:
+    image = add_image_reference.Image.from_image_index_url_and_digest(
+        "quay.io/namespace/repository/image:tag", "sha256:digest"
+    )
+
+    result = add_image_reference.update_name({"spdxVersion": "1.1.1"}, image)
+    assert result["name"] == "quay.io/namespace/repository/image@sha256:digest"
+
+
+@patch("json.dump")
+@patch("json.load")
+@patch("add_image_reference.update_name")
+@patch("add_image_reference.extend_sbom_with_image_reference")
+@patch("add_image_reference.Image.from_image_index_url_and_digest")
+@patch("builtins.open")
+@patch("add_image_reference.setup_arg_parser")
+def test_main(
+    mock_parser: MagicMock,
+    mock_open: MagicMock,
+    mock_image: MagicMock,
+    mock_extend_sbom: MagicMock,
+    mock_name: MagicMock,
+    mock_load: MagicMock,
+    mock_dump: MagicMock,
+) -> None:
+    add_image_reference.main()
+
+    mock_parser.assert_called_once()
+    mock_parser.return_value.parse_args.assert_called_once()
+    mock_image.assert_called_once()
+    assert mock_open.call_count == 2
+
+    mock_load.assert_called_once()
+    mock_extend_sbom.assert_called_once()
+    mock_name.assert_called_once()
+    mock_dump.assert_called_once()

--- a/sbom-utility-scripts/scripts/add-image-reference-script/tox.ini
+++ b/sbom-utility-scripts/scripts/add-image-reference-script/tox.ini
@@ -1,0 +1,19 @@
+[tox]
+env_list = flake8,black,test
+
+[testenv:test]
+deps = -r requirements-test.txt
+       -r requirements.txt
+commands = pytest ./ \
+    -vv \
+    --cov=add_image_reference \
+    --cov-report=term-missing \
+    --cov-fail-under 100 {posargs:.}
+
+[testenv:flake8]
+deps = flake8
+commands = flake8 --max-line-length 120 .
+
+[testenv:black]
+deps = black
+commands = black --line-length 120 --check --diff .


### PR DESCRIPTION
The script is responsible for expanding a image sbom by adding a reference pointing to the image into a SBOM content.

The script recognize an input format and adds necessary data into the list of components or packages. The script also sets a name of the SBOM based on a pullspec.

JIRA: ISV-5411, ISV-5320