### PR TITLE
add .idea directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .venv/
 .coverage
 __pycache__/
+.idea/


### PR DESCRIPTION
.idea is a directory used by the JetBrains family of IDEs for storing project-specific settings files and shouldn't be versioned