### PR TITLE
Add new image to inject image content manifest

### DIFF
--- a/icm-injection-scripts/Containerfile
+++ b/icm-injection-scripts/Containerfile
@@ -1,0 +1,16 @@
+FROM quay.io/konflux-ci/buildah-task:latest@sha256:b2d6c32d1e05e91920cd4475b2761d58bb7ee11ad5dff3ecb59831c7572b4d0c
+
+WORKDIR /scripts
+
+COPY scripts/inject-icm.sh /scripts
+
+LABEL \
+  description="Inject an ICM (image content manifest) file with content sets for backwards compatibility." \
+  io.k8s.description="Inject an ICM (image content manifest) file with content sets for backwards compatibility." \
+  summary="Inject an ICM (image content manifest) file" \
+  io.k8s.display-name="Inject an ICM (image content manifest) file" \
+  name="Inject an ICM (image content manifest) file" \
+  com.redhat.component="inject-icm"
+
+ENTRYPOINT ["/scripts/inject-icm.sh"]
+

--- a/icm-injection-scripts/scripts/inject-icm.sh
+++ b/icm-injection-scripts/scripts/inject-icm.sh
@@ -14,8 +14,7 @@
 
 set -euo pipefail
 
-CONTAINER="${1}"
-IMAGE="${2}"
+IMAGE="${1}"
 SQUASH="${SQUASH:-false}"
 
 icm_filename="content-sets.json"
@@ -26,10 +25,14 @@ if [ ! -f "./sbom-cachi2.json" ]; then
   exit 0
 fi
 
-echo "Preparing construction of $location for container $CONTAINER to be committed as $IMAGE (squash: $SQUASH)"
-
+echo "Extracting annotations to copy to the modified image"
 base_image_name=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.name"}}' "$IMAGE" | cut -f1 -d'@')
 base_image_digest=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.digest"}}' "$IMAGE")
+
+echo "Creating container from $IMAGE"
+CONTAINER=$(buildah from --pull-never $IMAGE)
+
+echo "Preparing construction of $location for container $CONTAINER to be committed back as $IMAGE (squash: $SQUASH)"
 cat >content-sets.json <<EOF
 {
     "metadata": {

--- a/icm-injection-scripts/scripts/inject-icm.sh
+++ b/icm-injection-scripts/scripts/inject-icm.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Inject an ICM (image content manifest) file with content sets for backwards compatibility
+#
+# https://github.com/containerbuildsystem/atomic-reactor/blob/master/atomic_reactor/schemas/content_manifest.json
+#
+# This is not a file we want to inject always into the future, but older Red
+# Hat build systems injected a file like this and some third-party scanners
+# depend on it in order to map rpms found in each layer to CPE ids, to match
+# them with vulnerability data. In the future, those scanners should port to
+# using the dnf db and/or SBOMs to make that same match. Consider this
+# deprecated.
+#
+# This is only possible for images built hermetically with prefetch
+
+set -euo pipefail
+
+CONTAINER="${1}"
+IMAGE="${2}"
+SQUASH="${SQUASH:-false}"
+
+icm_filename="content-sets.json"
+location="/root/buildinfo/content_manifests/${icm_filename}"
+
+if [ ! -f "./sbom-cachi2.json" ]; then
+  echo "Could not find sbom-cachi2.json. No content_sets found for ICM"
+  exit 0
+fi
+
+echo "Preparing construction of $location for container $CONTAINER to be committed as $IMAGE (squash: $SQUASH)"
+
+base_image_name=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.name"}}' "$IMAGE" | cut -f1 -d'@')
+base_image_digest=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.digest"}}' "$IMAGE")
+cat >content-sets.json <<EOF
+{
+    "metadata": {
+	"icm_version": 1,
+	"icm_spec": "https://raw.githubusercontent.com/containerbuildsystem/atomic-reactor/master/atomic_reactor/schemas/content_manifest.json",
+	"image_layer_index": 0
+    },
+    "from_dnf_hint": true,
+    "content_sets": []
+}
+
+EOF
+
+while IFS='' read -r content_set;
+do
+  jq --arg content_set "$content_set" '.content_sets += [$content_set]' content-sets.json > content-sets.json.tmp
+  mv content-sets.json.tmp content-sets.json
+done <<< "$(jq -r '.components[].purl' sbom-cachi2.json | grep -o -P '(?<=repository_id=).*(?=(&|$))' | sort -u)"
+
+echo "Constructed the following:"
+cat content-sets.json
+
+echo "Writing that to $location"
+buildah copy "$CONTAINER" content-sets.json /root/buildinfo/content_manifests/
+buildah config -a "org.opencontainers.image.base.name=${base_image_name}" -a "org.opencontainers.image.base.digest=${base_image_digest}" "$CONTAINER"
+
+BUILDAH_ARGS=()
+if [ "${SQUASH}" == "true" ]; then
+  BUILDAH_ARGS+=("--squash")
+fi
+
+echo "Committing that back to $IMAGE"
+buildah commit "${BUILDAH_ARGS[@]}" "$CONTAINER" "$IMAGE"


### PR DESCRIPTION
For backwards compatibility with scanners that still expect to find this file.

Related: https://github.com/konflux-ci/build-definitions/pull/1771