### PR TITLE
fix(KONFLUX-6229) fix ICM injection for multiarch images

### DIFF
--- a/icm-injection-scripts/scripts/inject-icm.sh
+++ b/icm-injection-scripts/scripts/inject-icm.sh
@@ -17,6 +17,12 @@ set -euo pipefail
 IMAGE="${1}"
 SQUASH="${SQUASH:-false}"
 
+set +u
+if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
+  IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
+fi
+set -u
+
 icm_filename="content-sets.json"
 location="/root/buildinfo/content_manifests/${icm_filename}"
 


### PR DESCRIPTION
This ICM injection step accepts the IMAGE param as the image to operate on, which needs to account for whether or not the IMAGE_APPEND_PLATFORM param is also set to true.

https://issues.redhat.com/browse/KONFLUX-6229