### PR TITLE
remove release from sbom-utility-scripts GH action

### DIFF
--- a/.github/workflows/test-sbom-utility-scripts-image.yml
+++ b/.github/workflows/test-sbom-utility-scripts-image.yml
@@ -1,27 +1,22 @@
-name: Build sbom utility scripts image
+name: Test sbom utility scripts image
 
 on:
   push:
     branches:
       - main
     paths:
-      - .github/workflows/build-sbom-utility-scripts-image.yml
+      - .github/workflows/test-sbom-utility-scripts-image.yml
       - sbom-utility-scripts/**
 
   pull_request:
     branches:
       - main
     paths:
-      - .github/workflows/build-sbom-utility-scripts-image.yml
+      - .github/workflows/test-sbom-utility-scripts-image.yml
       - sbom-utility-scripts/**
 
-
-env:
-  REGISTRY: quay.io/redhat-appstudio
-  IMAGE_NAME: sbom-utility-scripts-image
-
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
 
     steps:
@@ -56,25 +51,3 @@ jobs:
         python3 -m pip install tox
         cd ./sbom-utility-scripts/scripts/add-image-reference-script/
         tox
-
-    - name: Build Image
-      id: build-image
-      uses: redhat-actions/buildah-build@v2
-      with:
-        image: ${{ env.IMAGE_NAME }}
-        tags: |
-          ${{ github.sha }}
-          latest
-        context: ./sbom-utility-scripts
-        containerfiles: |
-            ./sbom-utility-scripts/Dockerfile
-
-    - name: Push to Quay
-      if: github.event_name == 'push'  # don't push image from PR
-      uses: redhat-actions/push-to-registry@v2
-      with:
-        image: ${{ steps.build-image.outputs.image }}
-        tags: ${{ steps.build-image.outputs.tags }}
-        registry: ${{ env.REGISTRY }}
-        username: ${{ secrets.QUAY_USERNAME }}
-        password: ${{ secrets.QUAY_PASSWORD }}


### PR DESCRIPTION
- Build and release of sbom-utility-scripts image is now done via Konflux
- The `Build Image` and `Push to Quay` steps are no longer necessary
- Tox checks are still useful as testing though
- Since the workflow is now not building anymore, rename to
  `test-sbom-utility-scripts`
