### PR TITLE
add_image_reference: absolute paths are paths too

### DIFF
--- a/sbom-utility-scripts/scripts/add-image-reference-script/add_image_reference.py
+++ b/sbom-utility-scripts/scripts/add-image-reference-script/add_image_reference.py
@@ -266,7 +266,7 @@ def is_virtual_root(package: dict) -> bool:
         bool: A boolean indicating if the package is a virtual root.
     """
     name = package.get("name")
-    return not name or name.startswith(".")
+    return not name or name.startswith((".", "/"))
 
 
 def redirect_current_roots_to_new_root(sbom: dict, new_root: str) -> dict:

--- a/sbom-utility-scripts/scripts/add-image-reference-script/test_add_image_reference.py
+++ b/sbom-utility-scripts/scripts/add-image-reference-script/test_add_image_reference.py
@@ -118,6 +118,9 @@ def test_is_virtual_root() -> None:
     package["name"] = "./some-dir"
     assert add_image_reference.is_virtual_root(package) is True
 
+    package["name"] = "/some/absolute/path"
+    assert add_image_reference.is_virtual_root(package) is True
+
     package["name"] = "bar"
     assert add_image_reference.is_virtual_root(package) is False
 


### PR DESCRIPTION
When deciding whether a package is "virtual", treat names that start with "/" as paths too.