### PR TITLE
build-pipeline: add missing version tag

### DIFF
--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -196,7 +196,7 @@ spec:
         - name: name
           value: buildah-remote-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta@sha256:6c2c433ef94187e9aa73575004029cd6e2bbbdeefc7f90070595fb20f77bc121
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:6c2c433ef94187e9aa73575004029cd6e2bbbdeefc7f90070595fb20f77bc121
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
Somehow, the version tag for the buildah-remote-oci-ta task disappeared in https://github.com/konflux-ci/build-tasks-dockerfiles/pull/221.

Enterprise Contract doesn't recognize the tag-less task bundle, so it considers the task untrusted. Put the tag back.