### PR TITLE
Add build image support to add_image_reference

### DIFF
--- a/sbom-utility-scripts/scripts/add-image-reference-script/README.md
+++ b/sbom-utility-scripts/scripts/add-image-reference-script/README.md
@@ -1,10 +1,12 @@
 # Add image reference script
 
-The script aims to enrich the SBOM file with additional information about the output image used in the build process.
+The script aims to enrich the SBOM file with additional information about the output image used in the build process or an additional builder image used during the build process.
 Based on a input SBOM type, the script updates certain fields with the image reference information. This is needed
 to provide a complete SBOM file that can be used for further analysis.
 
 ## Usage
+
+The default behavior of the script will add information about the output image to the input SBOM.
 
 ```bash
 python add_image_reference.py \
@@ -15,8 +17,20 @@ python add_image_reference.py \
 ```
 The script stores the updated SBOM in the output path provided.
 
+Using `--builder-image` flag the image reference will be injected as an additional builder image.
+
+```bash
+python add_image_reference.py \
+    --builder-image \
+    --input-file ./input-sbom.json \
+    --output-file ./updated-sbom.json \
+    --image-url quay.io/foo/bar/builing-tools:2.1 \
+    --image-digest sha256:011ff0cd8f34588d3eca86da97619f7baf99c8cc12e24cc3a7f337873c8d36cc
+```
+
 ## List of updates
-### SPDX
+### Output image mode
+#### SPDX
 The script updates the following fields in the SPDX SBOM:SHA256
 - `packages` - the script adds a new package with the image reference information
 - `relationships` - the script adds a new relationship between the package and the image reference
@@ -65,7 +79,7 @@ SBOM after enrichment:
 
 ```
 
-#### Example
+##### Example
 ```json
 {
   "name": "quay.io/foo/bar/ubi8@sha256:011ff0cd8f34588d3eca86da97619f7baf99c8cc12e24cc3a7f337873c8d36cc",
@@ -103,11 +117,11 @@ SBOM after enrichment:
 
 ```
 
-### CycloneDX
+#### CycloneDX
 - `components` - the script adds a new component with the image reference information
 - `metadata.component` - the script adds the image reference as a metadata.component
 
-#### Example
+##### Example
 ```json
 {
   "metadata": {
@@ -139,6 +153,149 @@ SBOM after enrichment:
         }
       ]
     },
+  ]
+}
+```
+
+### Additional builder image mode
+#### SPDX image
+The script updates the following fields in the SPDX SBOM:SHA256
+- `packages` - the script adds a new package with the image reference information. The image will include an annotation specifying that the image is an additional builder image.
+- `relationships` - the script adds a new `<BASE_IMAGE> BUILD_TOOL_OF <ROOT>` relationship between the package and the image reference
+
+##### Example
+
+```json
+{
+  "name": "quay.io/foo/bar/ubi8@sha256:011ff0cd8f34588d3eca86da97619f7baf99c8cc12e24cc3a7f337873c8d36cc",
+  "packages": [
+    {
+      "SPDXID": "SPDXRef-image",
+      "name": "ubi8",
+      "versionInfo": "1.1",
+      "downloadLocation": "NOASSERTION",
+      "licenseConcluded": "NOASSERTION",
+      "supplier": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceLocator": "pkg:oci/ubi8@sha256:011ff0cd8f34588d3eca86da97619f7baf99c8cc12e24cc3a7f337873c8d36cc?repository_url=quay.io/foo/bar/ubi8",
+          "referenceType": "purl",
+          "referenceCategory": "PACKAGE-MANAGER"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "011ff0cd8f34588d3eca86da97619f7baf99c8cc12e24cc3a7f337873c8d36cc"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-image-building-tools-011ff0cd8f34588d3eca86da97619f7baf99c8cc12e24cc3a7f337873c8d36cc",
+      "name": "building-tools",
+      "versionInfo": "2.1",
+      "downloadLocation": "NOASSERTION",
+      "licenseConcluded": "NOASSERTION",
+      "supplier": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceLocator": "pkg:oci/ubi8@sha256:011ff0cd8f34588d3eca86da97619f7baf99c8cc12e24cc3a7f337873c8d36cc?repository_url=quay.io/foo/bar/building-tools",
+          "referenceType": "purl",
+          "referenceCategory": "PACKAGE-MANAGER"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "011ff0cd8f34588d3eca86da97619f7baf99c8cc12e24cc3a7f337873c8d36cc"
+        }
+      ],
+      "annotations": [
+        {
+            "annotationDate": "2025-03-12T00:00:00Z",
+            "annotationType": "OTHER",
+            "annotator": "Tool: konflux:jsonencoded",
+            "comment": "{\"name\":\"konflux:container:is_builder_image:additional_builder_image\",\"value\":\"script-runner-image\"}",
+        }
+        ]
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-image"
+    },
+    {
+        "spdxElementId": "SPDXRef-image-building-tools-011ff0cd8f34588d3eca86da97619f7baf99c8cc12e24cc3a7f337873c8d36cc",
+        "relationshipType": "BUILD_TOOL_OF",
+        "relatedSpdxElement": "SPDXRef-image",
+    }
+  ]
+}
+
+```
+
+#### CycloneDX
+
+- `formulation` - the script adds a new formulation with the image reference information in `formulation.components`
+
+```json
+{
+  "metadata": {
+    "component": {
+      "type": "container",
+      "name": "ubi8",
+      "purl": "pkg:oci/ubi8@sha256:011ff0cd8f34588d3eca86da97619f7baf99c8cc12e24cc3a7f337873c8d36cc?repository_url=quay.io/foo/bar/ubi8",
+      "version": "1.1",
+      "publisher": "Red Hat, Inc.",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "011ff0cd8f34588d3eca86da97619f7baf99c8cc12e24cc3a7f337873c8d36cc"
+        }
+      ]
+    },
+  },
+  "components": [
+    {
+      "type": "container",
+      "name": "ubi8",
+      "purl": "pkg:oci/ubi8@sha256:011ff0cd8f34588d3eca86da97619f7baf99c8cc12e24cc3a7f337873c8d36cc?repository_url=quay.io/foo/bar/ubi8",
+      "version": "1.1",
+      "publisher": "Red Hat, Inc.",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "011ff0cd8f34588d3eca86da97619f7baf99c8cc12e24cc3a7f337873c8d36cc"
+        }
+      ]
+    },
+  ],
+  "formulation": [
+    {
+      "component": [
+        {
+          "type": "container",
+          "name": "building-tools",
+          "purl": "pkg:oci/ubi8@sha256:011ff0cd8f34588d3eca86da97619f7baf99c8cc12e24cc3a7f337873c8d36cc?repository_url=quay.io/foo/bar/ubi8",
+          "version": "2.1",
+          "publisher": "Red Hat, Inc.",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "011ff0cd8f34588d3eca86da97619f7baf99c8cc12e24cc3a7f337873c8d36cc"
+            }
+          ],
+          "properties": [
+            {
+              "name": "konflux:container:is_builder_image:additional_builder_image",
+              "value": "script-runner-image",
+            }
+          ]
+        }
+      ]
+    }
   ]
 }
 ```

--- a/sbom-utility-scripts/scripts/add-image-reference-script/test_add_image_reference.py
+++ b/sbom-utility-scripts/scripts/add-image-reference-script/test_add_image_reference.py
@@ -1,5 +1,8 @@
 from unittest.mock import MagicMock, patch
 
+import datetime
+import pytest
+
 import add_image_reference
 
 
@@ -12,7 +15,7 @@ def test_setup_arg_parser() -> None:
 
 def test_Image() -> None:
     image = add_image_reference.Image.from_image_index_url_and_digest(
-        "quay.io/namespace/repository/image:tag", "sha256:digest"
+        "quay.io/namespace/repository/image:tag", "sha256:digest", False
     )
 
     assert image.repository == "quay.io/namespace/repository/image"
@@ -27,27 +30,44 @@ def test_Image() -> None:
     assert image.purl() == ("pkg:oci/image@sha256:digest?repository_url=quay.io/namespace/repository/image")
 
 
-def test_update_component_in_cyclonedx_sbom() -> None:
+@pytest.mark.parametrize(
+    "builder_image,components_count", [(True, 1), (False, 2)], ids=["build-image", "component-image"]
+)
+def test_update_component_in_cyclonedx_sbom(builder_image: bool, components_count: int) -> None:
     sbom = {"bomFormat": "CycloneDX", "metadata": {"component": {}}, "components": [{}]}
     image = add_image_reference.Image.from_image_index_url_and_digest(
         "quay.io/namespace/repository/image:tag",
         "sha256:digest",
+        builder_image,
     )
 
     result = add_image_reference.update_component_in_cyclonedx_sbom(sbom=sbom, image=image)
 
-    assert (
-        result["metadata"]["component"]["purl"]
-        == "pkg:oci/image@sha256:digest?repository_url=quay.io/namespace/repository/image"
-    )
-    assert len(result["components"]) == 2
-    assert result["components"][0] == {
+    image_sbom = {
         "type": "container",
         "name": image.name,
         "purl": image.purl(),
         "version": image.tag,
         "hashes": [{"alg": image.digest_algo_cyclonedx, "content": image.digest_hex_val}],
     }
+
+    if builder_image:
+        location = result["formulation"][0]["components"][0]
+        image_sbom_proterty = {
+            "name": "konflux:container:is_builder_image:additional_builder_image",
+            "value": "script-runner-image",
+        }
+        image_sbom["properties"] = [image_sbom_proterty]
+        assert location
+    else:
+        location = result["components"][0]
+        assert (
+            result["metadata"]["component"]["purl"]
+            == "pkg:oci/image@sha256:digest?repository_url=quay.io/namespace/repository/image"
+        )
+    assert len(result["components"]) == components_count
+
+    assert location == image_sbom
     assert result["metadata"]["component"] == result["components"][0]
 
 
@@ -195,12 +215,92 @@ def test_redirect_current_roots_to_new_root() -> None:
     }
 
 
+@pytest.mark.parametrize(
+    "sbom,expected_output",
+    [
+        # SPDX with no root package
+        (
+            {
+                "SPDXID": "SPDXRef-Document",
+                "spdxVersion": "SPDX-2.3",
+                "name": "MyProject",
+                "documentNamespace": "http://example.com/uid-1234",
+            },
+            ValueError(r"Found 0 ROOTs: \[\]"),
+        ),
+        # SPDX with too many roots
+        (
+            {
+                "SPDXID": "SPDXRef-Document",
+                "spdxVersion": "SPDX-2.3",
+                "name": "MyProject",
+                "documentNamespace": "http://example.com/uid-1234",
+                "packages": [
+                    {
+                        "SPDXID": "SPDXRef-root1",
+                        "name": "",
+                        "downloadLocation": "NOASSERTION",
+                    },
+                    {
+                        "SPDXID": "SPDXRef-root2",
+                        "name": "",
+                        "downloadLocation": "NOASSERTION",
+                    },
+                ],
+                "relationships": [
+                    {
+                        "spdxElementId": "SPDXRef-Document",
+                        "relationshipType": "DESCRIBES",
+                        "relatedSpdxElement": "SPDXRef-root1",
+                    },
+                    {
+                        "spdxElementId": "SPDXRef-Document",
+                        "relationshipType": "DESCRIBES",
+                        "relatedSpdxElement": "SPDXRef-root2",
+                    },
+                ],
+            },
+            ValueError(r"Found 2 ROOTs: \['SPDXRef-root1', 'SPDXRef-root2'\]"),
+        ),
+        # minimal valid SPDX SBOM
+        (
+            {
+                "SPDXID": "SPDXRef-Document",
+                "spdxVersion": "SPDX-2.3",
+                "name": "MyProject",
+                "documentNamespace": "http://example.com/uid-1234",
+                "packages": [
+                    {
+                        "SPDXID": "SPDXRef-image-my-cool-image",
+                        "name": "MyMainPackage",
+                        "downloadLocation": "NOASSERTION",
+                    },
+                ],
+                "relationships": [
+                    {
+                        "spdxElementId": "SPDXRef-Document",
+                        "relationshipType": "DESCRIBES",
+                        "relatedSpdxElement": "SPDXRef-image-my-cool-image",
+                    },
+                ],
+            },
+            "SPDXRef-image-my-cool-image",
+        ),
+    ],
+)
+def test_find_spdx_root_package(sbom, expected_output) -> None:
+    if not isinstance(expected_output, Exception):
+        assert add_image_reference.find_spdx_root_package(sbom) == expected_output
+    else:
+        with pytest.raises(type(expected_output), match=str(expected_output)):
+            add_image_reference.find_spdx_root_package(sbom)
+
+
 @patch("add_image_reference.redirect_current_roots_to_new_root")
 def test_update_package_in_spdx_sbom(mock_root_redicret: MagicMock) -> None:
     sbom = {"spdxVersion": "1.1.1", "SPDXID": "foo", "packages": [{}], "relationships": []}
     image = add_image_reference.Image.from_image_index_url_and_digest(
-        "quay.io/namespace/repository/image:tag",
-        "sha256:digest",
+        "quay.io/namespace/repository/image:tag", "sha256:digest", False
     )
 
     result = add_image_reference.update_package_in_spdx_sbom(sbom=sbom, image=image)
@@ -233,6 +333,68 @@ def test_update_package_in_spdx_sbom(mock_root_redicret: MagicMock) -> None:
     mock_root_redicret.assert_called_once_with(sbom, "SPDXRef-image")
 
 
+@patch("add_image_reference._datetime_utc_now", return_value=datetime.datetime(2025, 3, 12))
+def test_update_package_in_spdx_sbom_builder_image(mock_dt) -> None:
+    sbom = {
+        "SPDXID": "SPDXRef-Document",
+        "spdxVersion": "SPDX-2.3",
+        "name": "MyProject",
+        "documentNamespace": "http://example.com/uid-1234",
+        "packages": [
+            {
+                "SPDXID": "SPDXRef-image-my-cool-image",
+                "name": "MyMainPackage",
+                "downloadLocation": "NOASSERTION",
+            },
+        ],
+        "relationships": [
+            {
+                "spdxElementId": "SPDXRef-Document",
+                "relationshipType": "DESCRIBES",
+                "relatedSpdxElement": "SPDXRef-image-my-cool-image",
+            },
+        ],
+    }
+    image = add_image_reference.Image.from_image_index_url_and_digest(
+        "quay.io/namespace/repository/image:tag", "sha256:digest", True
+    )
+
+    result = add_image_reference.update_package_in_spdx_sbom(sbom=sbom, image=image)
+
+    assert len(result["packages"]) == 2
+    assert result["packages"][1] == {
+        "SPDXID": image.spdx_id,
+        "name": image.name,
+        "versionInfo": image.tag,
+        "downloadLocation": "NOASSERTION",
+        "licenseConcluded": "NOASSERTION",
+        "supplier": "NOASSERTION",
+        "externalRefs": [
+            {
+                "referenceLocator": image.purl(),
+                "referenceType": "purl",
+                "referenceCategory": "PACKAGE-MANAGER",
+            }
+        ],
+        "checksums": [{"algorithm": image.digest_algo_spdx, "checksumValue": image.digest_hex_val}],
+        "annotations": [
+            {
+                "annotationDate": "2025-03-12T00:00:00Z",
+                "annotationType": "OTHER",
+                "annotator": "Tool: konflux:jsonencoded",
+                "comment": '{"name":"konflux:container:is_builder_image:additional_builder_image","value":"script-runner-image"}',  # noqa: E501
+            }
+        ],
+    }
+
+    assert len(result["relationships"]) == 2
+    assert result["relationships"][1] == {
+        "spdxElementId": image.spdx_id,
+        "relationshipType": "BUILD_TOOL_OF",
+        "relatedSpdxElement": "SPDXRef-image-my-cool-image",
+    }
+
+
 @patch("add_image_reference.update_package_in_spdx_sbom")
 @patch("add_image_reference.update_component_in_cyclonedx_sbom")
 def test_extend_sbom_with_image_reference(cyclonedx_update: MagicMock, spdx_update: MagicMock) -> None:
@@ -255,7 +417,7 @@ def test_extend_sbom_with_image_reference(cyclonedx_update: MagicMock, spdx_upda
 
 def test_update_name() -> None:
     image = add_image_reference.Image.from_image_index_url_and_digest(
-        "quay.io/namespace/repository/image:tag", "sha256:digest"
+        "quay.io/namespace/repository/image:tag", "sha256:digest", False
     )
 
     result = add_image_reference.update_name({"spdxVersion": "1.1.1"}, image)
@@ -266,7 +428,12 @@ def test_update_name() -> None:
 @patch("json.load")
 @patch("add_image_reference.update_name")
 @patch("add_image_reference.extend_sbom_with_image_reference")
-@patch("add_image_reference.Image.from_image_index_url_and_digest")
+@patch(
+    "add_image_reference.Image.from_image_index_url_and_digest",
+    return_value=add_image_reference.Image(
+        "quay.io/namespace/repository/image", "image", "sha256:digest", "latest", False
+    ),
+)
 @patch("builtins.open")
 @patch("add_image_reference.setup_arg_parser")
 def test_main(
@@ -288,4 +455,38 @@ def test_main(
     mock_load.assert_called_once()
     mock_extend_sbom.assert_called_once()
     mock_name.assert_called_once()
+    mock_dump.assert_called_once()
+
+
+@patch("json.dump")
+@patch("json.load")
+@patch("add_image_reference.update_name")
+@patch("add_image_reference.extend_sbom_with_image_reference")
+@patch(
+    "add_image_reference.Image.from_image_index_url_and_digest",
+    return_value=add_image_reference.Image(
+        "quay.io/namespace/repository/image", "image", "sha256:digest", "latest", True
+    ),
+)
+@patch("builtins.open")
+@patch("add_image_reference.setup_arg_parser")
+def test_main_builder_image(
+    mock_parser: MagicMock,
+    mock_open: MagicMock,
+    mock_image: MagicMock,
+    mock_extend_sbom: MagicMock,
+    mock_name: MagicMock,
+    mock_load: MagicMock,
+    mock_dump: MagicMock,
+) -> None:
+    add_image_reference.main()
+
+    mock_parser.assert_called_once()
+    mock_parser.return_value.parse_args.assert_called_once()
+    mock_image.assert_called_once()
+    assert mock_open.call_count == 2
+
+    mock_load.assert_called_once()
+    mock_extend_sbom.assert_called_once()
+    mock_name.assert_not_called()
     mock_dump.assert_called_once()


### PR DESCRIPTION
The intent of this PR is to extend the funcionality of `add_image_reference.py` script to be able to inject build image references when the script is called with `--build-image` flag.

This is useful for https://github.com/konflux-ci/build-definitions/pull/2044 to be able to inject the image that was used to run the script as part of the build images on the final sbom.

The script's default functionality continues being the same when is executed without `--build-image` .

Calling it with the new flag will change the functionality to:

1.  Add a `properties` block to the package injected on the sbom. The resultant package will be something like this:

```
            "components": [
                {
                    "type": "container",
                    "name": "quay.io/mkosiarc_rhtap/single-container-app",
                    "purl": "pkg:oci/single-container-app@sha256:8f99627e843e931846855c5d899901bf093f5093e613a92745696a26b5420941?repository_url=quay.io/mkosiarc_rhtap/single-container-app",
                    "properties": [
                        {
                            "name": "konflux:container:is_builder_image:for_stage",
                            "value": "0",
                        }
                    ]
                }
```

2. For cyclone format:
    -  the package will not overwride the `metadata[component]` block
    - the package will be appended to the `formulation` section instead of `components` section

3. For SPDX format:
    - the package will not be colocated on the root of the document
    - the package will be injected with a `BUILD_TOOL_OF` relationship with the root package.

These changes are following the same format `base-images-sbom-script` uses to inject the base images coming from the Containerfile.

The main reason to colocate the functionality here and not on `base-images-sbom-script` is that the `base-images-sbom-script` logic is dependant on the content of the Dockerfile to inject the images. The changes the script would need to add arbitrary new build images that are not present on the Dockerfile would be big. Meanwhile the changes to repurpose this script to handle the original case and the new case are much smaller. An independent new script would be an option too, but the overlap of the code between `add_image_reference` and the new script would be huge.

TODO
- Finish SPDX tests
- Update README.md
- Update docstrings of the modified functions