### PR TITLE
Add parameter to allow dynamic SPDX ID generation from Image

### DIFF
--- a/sbom-utility-scripts/scripts/add-image-reference-script/add_image_reference.py
+++ b/sbom-utility-scripts/scripts/add-image-reference-script/add_image_reference.py
@@ -122,6 +122,12 @@ def setup_arg_parser() -> argparse.ArgumentParser:
         type=str,
         help="Path to save the output SBOM in JSON format.",
     )
+    parser.add_argument(
+        "--generate-id",
+        default=False,
+        type=bool,
+        help="Whether to generate a SPDX ID out of the image name and digest. Defaults to False.",
+    )
     return parser
 
 
@@ -305,7 +311,20 @@ def redirect_current_roots_to_new_root(sbom: dict, new_root: str) -> dict:
     return sbom
 
 
-def update_package_in_spdx_sbom(sbom: dict, image: Image) -> dict:
+def get_spdxid_from_image(image: Image) -> str:
+    """
+    Generate a SPDX ID from an image repository and digest
+
+    Args:
+        image (Image): Image to generate the SPDX ID from.
+
+    Returns:
+        str: SPDX ID in the format SPDXRef-image-{image.repository}-{image.digest}.
+    """
+    return f"SPDXRef-image-{image.repository}-{image.digest}"
+
+
+def update_package_in_spdx_sbom(sbom: dict, image: Image, generate_id: bool = False) -> dict:
     """
     Update the SPDX SBOM with the image reference.
 
@@ -315,13 +334,17 @@ def update_package_in_spdx_sbom(sbom: dict, image: Image) -> dict:
     Args:
         sbom (dict): SBOM in JSON format.
         image (Image): An instance of the Image class that represents the image.
+        generate_id (bool): Indicate if the SPDX ID should be generated.
 
     Returns:
         dict: Updated SBOM with the image reference added.
     """
+
+    spdxid = get_spdxid_from_image(image) if generate_id else "SPDXRef-image"
+
     # Add the image package to the packages list
     package = {
-        "SPDXID": "SPDXRef-image",
+        "SPDXID": spdxid,
         "name": image.name,
         "versionInfo": image.tag,
         "downloadLocation": "NOASSERTION",
@@ -353,7 +376,7 @@ def update_package_in_spdx_sbom(sbom: dict, image: Image) -> dict:
     return sbom
 
 
-def extend_sbom_with_image_reference(sbom: dict, image: Image) -> dict:
+def extend_sbom_with_image_reference(sbom: dict, image: Image, generate_id: bool = False) -> dict:
     """
     Extend the SBOM with the image reference.
     Based on the SBOM format, the image reference is added to the SBOM in
@@ -362,6 +385,7 @@ def extend_sbom_with_image_reference(sbom: dict, image: Image) -> dict:
     Args:
         sbom (dict): SBOM in JSON format.
         image (Image): An instance of the Image class that represents the image.
+        generate_id (bool): Indicate if the SPDX ID should be generated.
 
     Returns:
         dict: Updated SBOM with the image reference added.
@@ -369,7 +393,7 @@ def extend_sbom_with_image_reference(sbom: dict, image: Image) -> dict:
     if sbom.get("bomFormat") == "CycloneDX":
         update_component_in_cyclonedx_sbom(sbom, image)
     elif "spdxVersion" in sbom:
-        update_package_in_spdx_sbom(sbom, image)
+        update_package_in_spdx_sbom(sbom, image, generate_id)
 
     return sbom
 
@@ -406,7 +430,7 @@ def main():
     )
 
     # Update the input SBOM with the image reference and name attributes
-    sbom = extend_sbom_with_image_reference(sbom, image)
+    sbom = extend_sbom_with_image_reference(sbom, image, args.generate_id)
     sbom = update_name(sbom, image)
 
     # Save the updated SBOM to the output file

--- a/sbom-utility-scripts/scripts/add-image-reference-script/test_add_image_reference.py
+++ b/sbom-utility-scripts/scripts/add-image-reference-script/test_add_image_reference.py
@@ -1,5 +1,7 @@
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 import add_image_reference
 
 
@@ -196,18 +198,26 @@ def test_redirect_current_roots_to_new_root() -> None:
 
 
 @patch("add_image_reference.redirect_current_roots_to_new_root")
-def test_update_package_in_spdx_sbom(mock_root_redicret: MagicMock) -> None:
+@pytest.mark.parametrize(
+    "generate_id,expected_spdxid",
+    [
+        (True, "SPDXRef-image-quay.io/namespace/repository/image-sha256:digest"),
+        (False, "SPDXRef-image"),
+        (None, "SPDXRef-image"),
+    ],
+)
+def test_update_package_in_spdx_sbom(mock_root_redicret: MagicMock, generate_id, expected_spdxid) -> None:
     sbom = {"spdxVersion": "1.1.1", "SPDXID": "foo", "packages": [{}], "relationships": []}
     image = add_image_reference.Image.from_image_index_url_and_digest(
         "quay.io/namespace/repository/image:tag",
         "sha256:digest",
     )
 
-    result = add_image_reference.update_package_in_spdx_sbom(sbom=sbom, image=image)
+    result = add_image_reference.update_package_in_spdx_sbom(sbom=sbom, image=image, generate_id=generate_id)
 
     assert len(result["packages"]) == 2
     assert result["packages"][0] == {
-        "SPDXID": "SPDXRef-image",
+        "SPDXID": expected_spdxid,
         "name": image.name,
         "versionInfo": image.tag,
         "downloadLocation": "NOASSERTION",
@@ -227,10 +237,10 @@ def test_update_package_in_spdx_sbom(mock_root_redicret: MagicMock) -> None:
     assert result["relationships"][0] == {
         "spdxElementId": sbom["SPDXID"],
         "relationshipType": "DESCRIBES",
-        "relatedSpdxElement": "SPDXRef-image",
+        "relatedSpdxElement": expected_spdxid,
     }
 
-    mock_root_redicret.assert_called_once_with(sbom, "SPDXRef-image")
+    mock_root_redicret.assert_called_once_with(sbom, expected_spdxid)
 
 
 @patch("add_image_reference.update_package_in_spdx_sbom")
@@ -250,7 +260,7 @@ def test_extend_sbom_with_image_reference(cyclonedx_update: MagicMock, spdx_upda
     add_image_reference.extend_sbom_with_image_reference(sbom, image)
 
     cyclonedx_update.assert_not_called()
-    spdx_update.assert_called_once_with(sbom, image)
+    spdx_update.assert_called_once_with(sbom, image, False)
 
 
 def test_update_name() -> None:
@@ -289,3 +299,13 @@ def test_main(
     mock_extend_sbom.assert_called_once()
     mock_name.assert_called_once()
     mock_dump.assert_called_once()
+
+
+def test_get_spdxid_from_image():
+
+    image = add_image_reference.Image.from_image_index_url_and_digest(
+        "quay.io/namespace/repository/image:tag", "sha256:digest"
+    )
+
+    actual = add_image_reference.get_spdxid_from_image(image)
+    assert actual == "SPDXRef-image-quay.io/namespace/repository/image-sha256:digest"


### PR DESCRIPTION
Adds a parameter to optionally generate different SPDX IDs when adding new image references
