### PR TITLE
fix: CI to use sbom-utility-script and icm-injection-scripts image

### DIFF
--- a/integration-tests/pipelines/e2e-tests-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-tests-pipeline.yaml
@@ -12,10 +12,24 @@ spec:
       default: "build-templates-e2e"
       description: "namespace where e2e-tests will be executed"
   tasks:
+    - name: test-metadata
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: common/tasks/test-metadata/0.1/test-metadata.yaml
     - name: prepare-e2e-tests
       params:
         - name: SNAPSHOT
           value: $(params.SNAPSHOT)
+      when:
+        - input: "$(tasks.test-metadata.results.test-event-type)"
+          operator: in
+          values: ["pull_request"]
       taskSpec:
         params:
         - name: SNAPSHOT
@@ -59,6 +73,10 @@ spec:
           value: "main"
         - name: custom_build_bundle
           value: "$(tasks.prepare-e2e-tests.results.custom-build-bundle)"
+      when:
+        - input: "$(tasks.test-metadata.results.test-event-type)"
+          operator: in
+          values: ["pull_request"]
       runAfter:
         - prepare-e2e-tests
       taskRef:

--- a/integration-tests/pipelines/e2e-tests-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-tests-pipeline.yaml
@@ -20,28 +20,32 @@ spec:
         params:
         - name: SNAPSHOT
         results:
-          - name: custom-source-build-bundle
+          - name: custom-build-bundle
             description: "custom bundle for source build pipeline"
         steps:
           - name: e2e-tests
-            image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
+            image: quay.io/konflux-ci/appstudio-utils:48c311af02858e2422d6229600e9959e496ddef1@sha256:91ddd999271f65d8ec8487b10f3dd378f81aa894e11b9af4d10639fd52bba7e8
             env:
             - name: SNAPSHOT
               value: $(params.SNAPSHOT)
             script: |
+              set -e
               echo "SNAPSHOT: ${SNAPSHOT}"
-              export SOURCE_IMAGE=$(jq -r '.components[] | select(.name == "source-container-build") | .containerImage' <<< "$SNAPSHOT")
-              echo "Built image: ${SOURCE_IMAGE}"
-
-              git clone --branch main https://github.com/redhat-appstudio/e2e-tests.git
+              export SOURCE_BUILD_IMAGE=$(jq -r '.components[] | select(.name == "source-container-build") | .containerImage' <<< "$SNAPSHOT")
+              export SBOM_UTILITY_SCRIPTS_IMAGE=$(jq -r '.components[] | select(.name == "sbom-utility-scripts") | .containerImage' <<< "$SNAPSHOT")
+              export ICM_INJECTION_SCRIPTS_IMAGE=$(jq -r '.components[] | select(.name == "icm-injection-scripts") | .containerImage' <<< $SNAPSHOT)
+              git clone --branch main https://github.com/konflux-ci/e2e-tests.git
               cd e2e-tests/
-              make setup-source-build | tee cmd_output
+              make setup-bundle-for-build-tasks-dockerfiles-group-build | tee cmd_output
               last_line_output=$(tail -n 1 cmd_output)
               IFS='='
               read -ra arr <<< "$last_line_output"
-              custom_source_build_bundle=${arr[1]}
-
-              echo -n ${custom_source_build_bundle} | tee $(results.custom-source-build-bundle.path)
+              custom_pipeline_bundle=${arr[1]}
+              if [[ "$custom_pipeline_bundle" == "" ]]; then
+                echo "Failed to read pipeline bundle, exiting..."
+                exit 1
+              fi
+              echo -n ${custom_pipeline_bundle} | tee $(results.custom-build-bundle.path)
 
     - name: run-e2e-tests
       params:
@@ -53,8 +57,8 @@ spec:
           value: "https://github.com/konflux-ci/build-definitions.git"
         - name: ec_pipelines_repo_revision
           value: "main"
-        - name: custom_source_build_bundle
-          value: "$(tasks.prepare-e2e-tests.results.custom-source-build-bundle)"
+        - name: custom_build_bundle
+          value: "$(tasks.prepare-e2e-tests.results.custom-build-bundle)"
       runAfter:
         - prepare-e2e-tests
       taskRef:

--- a/integration-tests/tasks/e2e-test.yaml
+++ b/integration-tests/tasks/e2e-test.yaml
@@ -14,7 +14,7 @@ spec:
       type: string
     - name: ec_pipelines_repo_revision
       type: string
-    - name: custom_source_build_bundle
+    - name: custom_build_bundle
       type: string
   steps:
     - name: e2e-test
@@ -50,5 +50,5 @@ spec:
         value: $(params.ec_pipelines_repo_url)
       - name: EC_PIPELINES_REPO_REVISION
         value: $(params.ec_pipelines_repo_revision)
-      - name: CUSTOM_SOURCE_BUILD_PIPELINE_BUNDLE
-        value: $(params.custom_source_build_bundle)
+      - name: CUSTOM_BUILD_PIPELINE_BUNDLE
+        value: $(params.custom_build_bundle)


### PR DESCRIPTION
This PR will fix the issue of not using `sbom-utility-scripts` and `icm-injection-scripts` image not used during group pr CI execution
Part of https://issues.redhat.com/browse/STONEBLD-3174