### PR TITLE
fix(KONFLUX-7507) Allow content set to be specified in build

### DIFF
--- a/icm-injection-scripts/scripts/test-inject-icm.sh
+++ b/icm-injection-scripts/scripts/test-inject-icm.sh
@@ -29,7 +29,7 @@ cd "$WORKDIR"
 
 banner "Running inject-icm.sh with a $TEST_SBOM_FORMAT SBOM"
 cp "$SCRIPTDIR/test-data/sbom-cachi2-$TEST_SBOM_FORMAT.json" ./sbom-cachi2.json
-bash "$SCRIPTDIR/inject-icm.sh" "$TEST_IMAGE"
+bash "$SCRIPTDIR/inject-icm.sh" "$TEST_IMAGE" "/tmp"
 
 expect_icm=$(jq -n '{
   "metadata": {


### PR DESCRIPTION
When we add the content-sets.json file, we also add an additional layer to the image. If any user has expectations about layer content, adding this layer will violate assumtions. We still want to ensure that the content-sets.json file is accurate, but we can allow users to add it on their own and just validate its accuracy.