### PR TITLE
[ISV-5705], [ISV-5706] Download parent image SBOM and implement decision tree.

### DIFF
--- a/sbom-utility-scripts/Dockerfile
+++ b/sbom-utility-scripts/Dockerfile
@@ -1,4 +1,10 @@
+FROM ghcr.io/sigstore/cosign/cosign:v2.5.0 as cosign-bin
+# Install cosign command, reference:
+# https://github.com/sigstore/cosign?tab=readme-ov-file
+
 FROM registry.access.redhat.com/ubi9/python-312:9.5-1739191330@sha256:4b4a9f1208c49ecb274647e65f1e4544621f13ebbce31a743775bbd57f583529
+
+COPY --from=cosign-bin /ko-app/cosign /usr/bin/cosign
 
 WORKDIR /scripts
 

--- a/sbom-utility-scripts/scripts/contextual-sbom/README.md
+++ b/sbom-utility-scripts/scripts/contextual-sbom/README.md
@@ -6,3 +6,5 @@
 
 - The parent image is identified
 - Runtime architecture is identified
+- Parent image is downloaded
+- The script stores a value determining if the contextual mechanism will be used

--- a/sbom-utility-scripts/scripts/contextual-sbom/test_create_contextual_sbom.py
+++ b/sbom-utility-scripts/scripts/contextual-sbom/test_create_contextual_sbom.py
@@ -1,9 +1,21 @@
 import json
+from pathlib import Path
 from typing import Any
+from unittest.mock import patch, MagicMock
 
 import pytest
 
-from create_contextual_sbom import get_base_images, get_parent_image, identify_arch
+from create_contextual_sbom import (
+    get_base_images,
+    get_parent_image_pullspec,
+    identify_arch,
+    use_contextual_sbom_creation,
+    ARCH_TRANSLATION,
+    download_parent_image_sbom,
+    _get_sbom_format,
+    SBOMFormat,
+    load_json,
+)
 
 
 @pytest.fixture(scope="session")
@@ -16,6 +28,18 @@ def sample1_parsed_dockerfile() -> dict[str, Any]:
 def sample2_parsed_dockerfile() -> dict[str, Any]:
     with open("test_data/sample2/parsed.json") as json_file:
         return json.load(json_file)
+
+
+@pytest.fixture(scope="session")
+def spdx_parent_sbom_bytes() -> bytes:
+    with open("test_data/fake_parent_sbom/parent_sbom.spdx.json", "rb") as sbom_file:
+        return sbom_file.read()
+
+
+@pytest.fixture(scope="session")
+def cdx_parent_sbom_bytes() -> bytes:
+    with open("test_data/fake_parent_sbom/parent_sbom.cdx.json", "rb") as sbom_file:
+        return sbom_file.read()
 
 
 def test_get_base_images(sample1_parsed_dockerfile: dict[str, Any]) -> None:
@@ -51,8 +75,55 @@ def test_get_parent_image(
 ):
     """For tested dockerfiles, visit the `test_data` directory."""
     parsed_file = sample1_parsed_dockerfile if sample_name == "sample1" else sample2_parsed_dockerfile
-    assert get_parent_image(parsed_file, target) == expected_spec
+    assert get_parent_image_pullspec(parsed_file, target) == expected_spec
 
-def test_identify_arch():
+
+def test_identify_arch_basic():
     res = identify_arch()
-    assert isinstance(res, str) and res
+    assert isinstance(res, str)
+    assert res.startswith("linux/")
+    assert res.removeprefix("linux/") in ARCH_TRANSLATION
+    assert any(f"linux/{arch}" == res for arch in {"amd64", "arm64", "ppc64le", "s390x"})
+
+
+@pytest.mark.parametrize(
+    ["uname_output", "expected_cosign_arch"],
+    [
+        (b"x64", "amd64"),
+        (b"x86_64", "amd64"),
+        (b"armv8b", "arm64"),
+        (b"arm", "arm64"),
+        (b"aarch64", "arm64"),
+        (b"armv8l", "arm64"),
+        (b"aarch64_be", "arm64"),
+        (b"ppcle", "ppc64le"),
+        (b"powerpc", "ppc64le"),
+        (b"ppc", "ppc64le"),
+        (b"ppc64", "ppc64le"),
+        (b"s390", "s390x"),
+    ],
+)
+@patch("create_contextual_sbom.subprocess")
+def test_identify_arch(mock_subprocess: MagicMock, uname_output: bytes, expected_cosign_arch: str):
+    mock_subprocess.run.return_value.stdout = uname_output
+    assert identify_arch() == f"linux/{expected_cosign_arch}"
+
+
+@pytest.mark.parametrize(
+    ["sbom_name", "expected_output"],
+    [("parent_sbom.spdx.json", True), ("parent_sbom.cdx.json", False)],
+)
+def test_use_contextual_sbom_creation(sbom_name: str, expected_output: bool):
+    path_to_file = Path("test_data/fake_parent_sbom") / sbom_name
+    assert use_contextual_sbom_creation(load_json(path_to_file)) == expected_output
+
+
+def test_use_contextual_sbom_creation_sbom_is_none():
+    assert use_contextual_sbom_creation(None) == False
+
+
+@patch("create_contextual_sbom.subprocess")
+def test_download_parent_image_sbom(mock_subprocess: MagicMock, spdx_parent_sbom_bytes: bytes):
+    mock_subprocess.run.return_value.stdout = spdx_parent_sbom_bytes
+    sbom_doc = download_parent_image_sbom("foo", "bar")
+    assert _get_sbom_format(sbom_doc) is SBOMFormat.SPDX2X

--- a/sbom-utility-scripts/scripts/contextual-sbom/test_data/fake_parent_sbom/parent_sbom.cdx.json
+++ b/sbom-utility-scripts/scripts/contextual-sbom/test_data/fake_parent_sbom/parent_sbom.cdx.json
@@ -1,0 +1,42 @@
+{
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.6",
+    "serialNumber": "urn:uuid:fc450d40-9073-4c03-a06b-c22defbf3772",
+    "version": 1,
+    "metadata": {
+        "timestamp": "1970-01-01T00:00:00Z",
+        "component": {
+            "bom-ref": "pkg:oci/konflux/yes@0.0.1?arch=x86_64",
+            "name": "yes",
+            "purl": "pkg:oci/konflux/yes@0.0.1?arch=x86_64",
+            "type": "container"
+        },
+        "supplier": {
+            "url": [
+                "https://example.url.konflux.dev"
+            ]
+        }
+    },
+    "dependencies": [
+        {
+            "ref": "pkg:oci/konflux/yes@0.0.1?arch=x86_64",
+            "dependsOn": [
+                "pkg:rpm/konflux/no@0.0.1?arch=x86_64"
+            ]
+        }
+    ],
+    "components": [
+        {
+            "name": "yes",
+            "bom-ref": "pkg:oci/konflux/yes@0.0.1?arch=x86_64",
+            "purl": "pkg:oci/konflux/yes@0.0.1?arch=x86_64",
+            "type": "container"
+        },
+        {
+            "name": "no",
+            "bom-ref": "pkg:rpm/konflux/no@0.0.1?arch=x86_64",
+            "purl": "pkg:rpm/konflux/no@0.0.1?arch=x86_64",
+            "type": "library"
+        }
+    ]
+}

--- a/sbom-utility-scripts/scripts/contextual-sbom/test_data/fake_parent_sbom/parent_sbom.spdx.json
+++ b/sbom-utility-scripts/scripts/contextual-sbom/test_data/fake_parent_sbom/parent_sbom.spdx.json
@@ -1,0 +1,51 @@
+{
+  "spdxVersion": "SPDX-2.3",
+  "dataLicense": "CC0-1.0",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "creationInfo": {
+    "created": "1970-01-01T00:00:00Z",
+    "creators": [
+      "Person: me (hello)"
+    ]
+  },
+  "name": "Very important parent image SBOM",
+  "documentNamespace": "https://example.url.konflux.dev/yes",
+  "packages": [
+    {
+      "SPDXID": "SPDXRef-1",
+      "name": "yes",
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:oci/konflux/yes@0.0.1?arch=x86_64"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-2",
+      "name": "no",
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:rpm/konflux/no@0.0.1?arch=x86_64"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-1"
+    },
+    {
+      "spdxElementId": "SPDXRef-1",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-2"
+    }
+  ]
+}


### PR DESCRIPTION
## Tickets for tracking:

- [ISV-5705] - Download parent image SBOM
- [ISV-5706] - Implement decision tree based on the SBOM

## How to test this (not only by unit tests)

You can try to run this by providing these example dockerfiles (parse them with `dockerfile-json` first):

```dockerfile
FROM quay.io/redhat-user-workloads/konflux-sec-eng-spec-tenant/nbde-tang-server-multiarch@sha256:727b82e5639c838fde5c5271574129bd43bb5b71c07bc4600e34275087cb72c3
# This is a multiarch image
CMD ["echo"]
```

```dockerfile
FROM quay.io/redhat-user-workloads/ocp-virt-images-tenant/release-console@sha256:5a36acb7ceae8288f8ba95b01119af7fce7d731d60a6915aff70a360764e6ab6
# This is a singlearch image
CMD ["echo"]
```

