### PR TITLE
Rebase source container image on fedora

### DIFF
--- a/source-container-build/Dockerfile
+++ b/source-container-build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi:9.6-1747219013
+FROM quay.io/fedora/fedora:latest@sha256:038a2cc23755fe0fd387587c0cb075c044d18bca103bdff56b46e6b3c564f9f7
 
 ARG BSI_VERSION=0.2.0
 ARG bsi_source=https://github.com/containers/BuildSourceImage/archive/refs/tags/v${BSI_VERSION}.tar.gz
@@ -8,7 +8,7 @@ ARG patch2=0001-Use-extra-src-archive-checksum-in-filename.patch
 ARG patch3=0001-Set-mediaType-on-image-manifest.patch
 
 # hadolint ignore=DL3041
-RUN dnf update -y && dnf install -y python3.11 git jq skopeo file tar && dnf clean all
+RUN dnf update -y && dnf install -y python3 git jq skopeo file tar && dnf clean all
 
 WORKDIR /opt/BuildSourceImage
 COPY $patch0 $patch1 $patch2 $patch3 ./
@@ -20,5 +20,5 @@ RUN curl -s -O -L $bsi_source && \
 
 WORKDIR /opt/source_build/
 COPY app/source_build.py app/requirements.txt ./
-RUN python3.11 -m venv appenv && \
+RUN python3 -m venv appenv && \
     ./appenv/bin/python3 -m pip install --no-cache-dir -r ./requirements.txt


### PR DESCRIPTION
The point is to get the new skopeo 1.19.

It includes this fix in containers/common: https://github.com/containers/common/pull/2378

Once skopeo 1.19 is released for ubi9, we can switch back to ubi9.