### PR TITLE
Enable hermetic builds

### DIFF
--- a/.tekton/sbom-utility-scripts-pull-request.yaml
+++ b/.tekton/sbom-utility-scripts-pull-request.yaml
@@ -36,6 +36,10 @@ spec:
     value: sbom-utility-scripts
   - name: build-source-image
     value: "true"
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '{"type": "pip", "path": "sbom-utility-scripts"}'
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/sbom-utility-scripts-push.yaml
+++ b/.tekton/sbom-utility-scripts-push.yaml
@@ -33,6 +33,10 @@ spec:
     value: sbom-utility-scripts
   - name: build-source-image
     value: "true"
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '{"type": "pip", "path": "sbom-utility-scripts"}'
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/source-container-build-pull-request.yaml
+++ b/.tekton/source-container-build-pull-request.yaml
@@ -37,6 +37,10 @@ spec:
     value: source-container-build
   - name: build-source-image
     value: "true"
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '{"type": "pip", "path": "source-container-build"}'
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/source-container-build-push.yaml
+++ b/.tekton/source-container-build-push.yaml
@@ -33,6 +33,10 @@ spec:
     value: source-container-build
   - name: build-source-image
     value: "true"
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '{"type": "pip", "path": "source-container-build"}'
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:


### PR DESCRIPTION
Enabling hermetic builds insulates the build process from the network. Doing that improves security by preventing outside interference.

In order to build hermetically, dependencies needed to build the container image have to be prefetched.

There are currently two components onboarded to Konflux:
- sbom-utility-scripts
- source-container-build 

Both of these are using Python, so their pip dependencies have to be prefetched.